### PR TITLE
fix(celery): `Celery.send_task` param `args`

### DIFF
--- a/tests/test_celery.py
+++ b/tests/test_celery.py
@@ -31,6 +31,10 @@ class HttpNotFound(Exception):
     ...
 
 
+app.send_task(name="main.add", args=(1, 2))
+app.send_task(name="main.add", args=[1, 2])
+
+
 @app.task(throws=(KeyError, HttpNotFound))
 def foo() -> None:
     print("foo")

--- a/typings/celery/app/base.pyi
+++ b/typings/celery/app/base.pyi
@@ -169,7 +169,7 @@ class Celery:
     def send_task(
         self,
         name: str,
-        args: Optional[Tuple[Any]] = ...,
+        args: Optional[Sequence[Any]] = ...,
         kwargs: Optional[Dict[str, Any]] = ...,
         countdown: Optional[float] = ...,
         eta: Optional[datetime.datetime] = ...,


### PR DESCRIPTION
Should have been a sequence, not a one element tuple.

https://github.com/sbdchd/celery-types/issues/16