### PR TITLE
fix(celery): Celery.task base param

### DIFF
--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -3,5 +3,6 @@
   "ignore": ["typings/django_celery_results*"],
   "reportPrivateUsage": false,
   "reportMissingModuleSource": false,
+  "reportIncompatibleMethodOverride": false,
   "reportUnusedFunction": false
 }

--- a/tests/test_celery.py
+++ b/tests/test_celery.py
@@ -40,6 +40,27 @@ def foo() -> None:
     print("foo")
 
 
+app_2 = celery.Celery("worker")
+
+
+class MyTask(celery.Task):
+    def on_failure(
+        self, exc: Exception, task_id: str, args: object, kwargs: object, einfo: object
+    ) -> None:
+        print("{0!r} failed: {1!r}".format(task_id, exc))
+
+    def foo(self) -> None:
+        print("foo")
+
+
+@app_2.task(base=MyTask)
+def add_3(x: int, y: int) -> None:
+    raise KeyError
+
+
+add_3.foo()
+
+
 def test_celery_calling_task() -> None:
     signature("tasks.add", args=(2, 2), countdown=10)
 

--- a/typings/celery/app/base.pyi
+++ b/typings/celery/app/base.pyi
@@ -10,7 +10,9 @@ from typing import (
     Set,
     Tuple,
     Type,
+    TypeVar,
     Union,
+    overload,
 )
 
 import celery
@@ -33,6 +35,8 @@ from celery.utils.dispatch import Signal
 from celery.utils.objects import FallbackContext
 from celery.utils.threads import _LocalStack
 from celery.worker import WorkController as CeleryWorkController
+
+_T = TypeVar("_T", bound=CeleryTask)
 
 class Celery:
     on_configure: Signal
@@ -102,6 +106,7 @@ class Celery:
     def close(self) -> None: ...
     def start(self, argv: Optional[List[str]] = ...) -> NoReturn: ...
     def worker_main(self, argv: Optional[List[str]] = ...) -> NoReturn: ...
+    @overload
     def task(
         self,
         *,
@@ -115,7 +120,42 @@ class Celery:
         ignore_result: bool = ...,
         soft_time_limit: int = ...,
         time_limit: int = ...,
-        base: Optional[CeleryTask] = ...,
+        base: Type[_T],
+        retry_kwargs: Dict[str, Any] = ...,
+        retry_backoff: bool = ...,
+        retry_backoff_max: int = ...,
+        retry_jitter: bool = ...,
+        typing: bool = ...,
+        rate_limit: Optional[str] = ...,
+        trail: bool = ...,
+        send_events: bool = ...,
+        store_errors_even_if_ignored: bool = ...,
+        autoregister: bool = ...,
+        track_started: bool = ...,
+        acks_on_failure_or_timeout: bool = ...,
+        reject_on_worker_lost: bool = ...,
+        throws: Tuple[Type[Exception], ...] = ...,
+        expires: Optional[Union[float, datetime.datetime]] = ...,
+        priority: Optional[int] = ...,
+        resultrepr_maxsize: int = ...,
+        request_stack: _LocalStack = ...,
+        abstract: bool = ...,
+    ) -> Callable[[Callable[..., Any]], _T]: ...
+    @overload
+    def task(
+        self,
+        *,
+        name: str = ...,
+        serializer: str = ...,
+        bind: bool = ...,
+        autoretry_for: Tuple[Type[Exception], ...] = ...,
+        max_retries: int = ...,
+        default_retry_delay: int = ...,
+        acks_late: bool = ...,
+        ignore_result: bool = ...,
+        soft_time_limit: int = ...,
+        time_limit: int = ...,
+        base: None = ...,
         retry_kwargs: Dict[str, Any] = ...,
         retry_backoff: bool = ...,
         retry_backoff_max: int = ...,


### PR DESCRIPTION
Previously typed as wanting an instance, but actually should be the base
type.

Add an overload so we return the proper type.

rel: https://github.com/sbdchd/celery-types/issues/20