### PR TITLE
fix(celery): shared_task base param

### DIFF
--- a/tests/test_celery.py
+++ b/tests/test_celery.py
@@ -55,6 +55,12 @@ def process_rows() -> None:
         print(row)
 
 
+@shared_task(base=DatabaseTask)
+def process_rows_2() -> None:
+    for row in process_rows_2.db.table.all():
+        print(row)
+
+
 @app.task(bind=True, default_retry_delay=10)
 def send_twitter_status(self: Task, oauth: str, tweet: str) -> None:
     try:

--- a/typings/celery/app/__init__.pyi
+++ b/typings/celery/app/__init__.pyi
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Any, Callable, Dict, Optional, Tuple, Type, Union
+from typing import Any, Callable, Dict, Optional, Tuple, Type, TypeVar, Union, overload
 
 from celery.app import beat as beat
 from celery.app import control as control
@@ -8,6 +8,8 @@ from celery.app import task as task
 from celery.app.task import Task as Task
 from celery.utils.threads import _LocalStack
 
+_T = TypeVar("_T", bound=Task)
+@overload
 def shared_task(
     *,
     name: str = ...,
@@ -20,7 +22,7 @@ def shared_task(
     ignore_result: bool = ...,
     soft_time_limit: int = ...,
     time_limit: int = ...,
-    base: Optional[Task] = ...,
+    base: None = ...,
     retry_kwargs: Dict[str, Any] = ...,
     retry_backoff: bool = ...,
     retry_backoff_max: int = ...,
@@ -41,5 +43,37 @@ def shared_task(
     request_stack: _LocalStack = ...,
     abstract: bool = ...,
 ) -> Callable[[Callable[..., Any]], Task]: ...
-
-__all__ = ["task"]
+@overload
+def shared_task(
+    *,
+    name: str = ...,
+    serializer: str = ...,
+    bind: bool = ...,
+    autoretry_for: Tuple[Type[Exception], ...] = ...,
+    max_retries: int = ...,
+    default_retry_delay: int = ...,
+    acks_late: bool = ...,
+    ignore_result: bool = ...,
+    soft_time_limit: int = ...,
+    time_limit: int = ...,
+    base: Type[_T],
+    retry_kwargs: Dict[str, Any] = ...,
+    retry_backoff: bool = ...,
+    retry_backoff_max: int = ...,
+    retry_jitter: bool = ...,
+    typing: bool = ...,
+    rate_limit: Optional[str] = ...,
+    trail: bool = ...,
+    send_events: bool = ...,
+    store_errors_even_if_ignored: bool = ...,
+    autoregister: bool = ...,
+    track_started: bool = ...,
+    acks_on_failure_or_timeout: bool = ...,
+    reject_on_worker_lost: bool = ...,
+    throws: Tuple[Type[Exception], ...] = ...,
+    expires: Optional[Union[float, datetime]] = ...,
+    priority: Optional[int] = ...,
+    resultrepr_maxsize: int = ...,
+    request_stack: _LocalStack = ...,
+    abstract: bool = ...,
+) -> Callable[[Callable[..., Any]], _T]: ...


### PR DESCRIPTION
Update the base param to match up with the task method on the Celery
class.

We need to keep these in sync -- haven't found a good way yet.