### PR TITLE
fix(celery): Celery.autodiscover_tasks packages param type

### DIFF
--- a/tests/test_celery.py
+++ b/tests/test_celery.py
@@ -157,6 +157,9 @@ def test_celery_calling_task() -> None:
 def test_celery_signals() -> None:
     app = Celery()
 
+    app.autodiscover_tasks(packages=["foo", "bar"])
+    app.autodiscover_tasks(packages=lambda: ["foo", "bar"])
+
     @app.on_after_configure.connect
     def setup_periodic_tasks(sender: Celery, **kwargs: object) -> None:
         # Calls test('hello') every 10 seconds.

--- a/typings/celery/app/base.pyi
+++ b/typings/celery/app/base.pyi
@@ -202,7 +202,7 @@ class Celery:
     ) -> None: ...
     def autodiscover_tasks(
         self,
-        packages: Optional[List[str]] = ...,
+        packages: List[str] | Callable[[], List[str]] | None = ...,
         related_name: str = ...,
         force: bool = ...,
     ) -> None: ...


### PR DESCRIPTION
Should accept a callable as well as a list.

rel: https://github.com/sbdchd/celery-types/issues/36