### PR TITLE
fix(celery): instance type instead of type constructor in Task.throws

### DIFF
--- a/celery-stubs/app/task.pyi
+++ b/celery-stubs/app/task.pyi
@@ -32,7 +32,7 @@ class Task:
     acks_late: bool
     acks_on_failure_or_timeout: bool
     reject_on_worker_lost: bool
-    throws: Tuple[Exception, ...]
+    throws: Tuple[Type[Exception], ...]
     expires: Optional[Union[float, datetime]]
     priority: Optional[int]
     resultrepr_maxsize: int

--- a/celery-stubs/app/task.pyi
+++ b/celery-stubs/app/task.pyi
@@ -1,5 +1,16 @@
 from datetime import datetime
-from typing import Any, Dict, Iterable, List, Mapping, Optional, Tuple, Union, overload
+from typing import (
+    Any,
+    Dict,
+    Iterable,
+    List,
+    Mapping,
+    Optional,
+    Tuple,
+    Type,
+    Union,
+    overload,
+)
 
 import billiard
 import celery

--- a/tests/test_celery.py
+++ b/tests/test_celery.py
@@ -115,6 +115,8 @@ add.chunks(zip(range(100), range(100)), 10).group().skew(start=1, stop=10)()
 
 
 class MyTask(celery.Task):
+    throws = (ValueError,)
+
     def on_failure(
         self, exc: Exception, task_id: str, args: object, kwargs: object, einfo: object
     ) -> None:


### PR DESCRIPTION
rel: https://github.com/sbdchd/celery-types/issues/43