### PR TITLE
fix(celery): canvas group signature to be more permissive

### DIFF
--- a/celery-stubs/canvas.pyi
+++ b/celery-stubs/canvas.pyi
@@ -10,6 +10,7 @@ from typing import (
     Tuple,
     TypeVar,
     Union,
+    overload,
 )
 
 import celery
@@ -292,6 +293,11 @@ class chunks(Signature):
     def group(self) -> _group: ...
 
 class group(Signature):
+    @overload
+    def __init__(
+        self, __tasks: group | abstract.CallableSignature | Iterable[Signature]
+    ) -> None: ...
+    @overload
     def __init__(
         self,
         *tasks: Signature,

--- a/tests/test_celery.py
+++ b/tests/test_celery.py
@@ -155,6 +155,13 @@ def test_celery_calling_task() -> None:
 
     app.control.broadcast("ping")
 
+    job = celery.group(add.s(5, x) for x in range(10))
+    print(job)
+
+    celery.group([add.s(2, 2), add.s(4, 4)])
+
+    celery.group(add.s(1, 1), add.s(1, 2), add.s(1, 3))
+
 
 def test_celery_signals() -> None:
     app = Celery()


### PR DESCRIPTION
Need to also accept generator expressions and iterables in canvas.group's
init.

rel: https://github.com/sbdchd/celery-types/issues/46

https://github.com/celery/celery/blob/37481fdd57a1ec036695a86d8f3d5e36f9ecf84c/celery/canvas.py#L1009-L1012