### PR TITLE
Add List type to crontab params

### DIFF
--- a/celery-stubs/schedules.pyi
+++ b/celery-stubs/schedules.pyi
@@ -62,7 +62,7 @@ class crontab(BaseSchedule):
     def __init__(
         self,
         minute: Union[str, int] = ...,
-        hour: Union[str, int] = ...,
+        hour: Union[str, int, List[int]] = ...,
         day_of_week: Union[str, int] = ...,
         day_of_month: Union[str, int] = ...,
         month_of_year: Union[str, int] = ...,

--- a/celery-stubs/schedules.pyi
+++ b/celery-stubs/schedules.pyi
@@ -61,11 +61,11 @@ class crontab_parser:
 class crontab(BaseSchedule):
     def __init__(
         self,
-        minute: Union[str, int] = ...,
+        minute: Union[str, int, List[int]] = ...,
         hour: Union[str, int, List[int]] = ...,
-        day_of_week: Union[str, int] = ...,
-        day_of_month: Union[str, int] = ...,
-        month_of_year: Union[str, int] = ...,
+        day_of_week: Union[str, int, List[int]] = ...,
+        day_of_month: Union[str, int, List[int]] = ...,
+        month_of_year: Union[str, int, List[int]] = ...,
         nowfun: Optional[Callable[[], datetime]] = ...,
         app: Optional[Celery] = ...,
     ) -> None: ...

--- a/celery-stubs/schedules.pyi
+++ b/celery-stubs/schedules.pyi
@@ -1,6 +1,6 @@
 import numbers
 from datetime import datetime, timedelta
-from typing import Callable, NamedTuple, Optional, Set, Tuple, Union
+from typing import Callable, List, NamedTuple, Optional, Set, Tuple, Union
 
 from celery.app.base import Celery
 from celery.utils.time import ffwd


### PR DESCRIPTION
I'm using crontab with Celery v4.4.2 like
```python
crontab(hour=[7, 19], minute=0)
```
and it's working fine, but these types are complaining...