### PR TITLE
Add queue string param to celery task decorator

### DIFF
--- a/celery-stubs/app/base.pyi
+++ b/celery-stubs/app/base.pyi
@@ -142,6 +142,7 @@ class Celery:
         resultrepr_maxsize: int = ...,
         request_stack: _LocalStack = ...,
         abstract: bool = ...,
+        queue: str = ...,
     ) -> Callable[[Callable[..., Any]], _T]: ...
     @overload
     def task(
@@ -177,6 +178,7 @@ class Celery:
         resultrepr_maxsize: int = ...,
         request_stack: _LocalStack = ...,
         abstract: bool = ...,
+        queue: str = ...,
     ) -> Callable[[Callable[..., Any]], CeleryTask]: ...
     def register_task(self, task: CeleryTask) -> CeleryTask: ...
     def gen_task_name(self, name: str, module: object) -> str: ...


### PR DESCRIPTION
Could not find the docs for this param, but we have been using it for a while and I believe it's forwarded to `apply_async` at some level