### PR TITLE
queue is optional arg to shared_task decorator

### DIFF
--- a/celery-stubs/app/__init__.pyi
+++ b/celery-stubs/app/__init__.pyi
@@ -43,6 +43,7 @@ def shared_task(
     resultrepr_maxsize: int = ...,
     request_stack: _LocalStack = ...,
     abstract: bool = ...,
+    queue: str = ...,
 ) -> Callable[[Callable[..., Any]], Task]: ...
 @overload
 def shared_task(
@@ -77,4 +78,5 @@ def shared_task(
     resultrepr_maxsize: int = ...,
     request_stack: _LocalStack = ...,
     abstract: bool = ...,
+    queue: str = ...,
 ) -> Callable[[Callable[..., Any]], _T]: ...


### PR DESCRIPTION
Adds `queue` as optional `str` arg to `shared_task` decorator