### PR TITLE
fix(celery): Fix signature of Celery.task with retry_backoff

### DIFF
--- a/celery-stubs/app/base.pyi
+++ b/celery-stubs/app/base.pyi
@@ -73,7 +73,7 @@ class Celery:
         # options
         autoretry_for: Tuple[Type[Exception], ...] = ...,
         retry_kwargs: Dict[str, Any] = ...,
-        retry_backoff: bool = ...,
+        retry_backoff: Union[bool, int] = ...,
         retry_backoff_max: int = ...,
         retry_jitter: bool = ...,
         # from task
@@ -124,7 +124,7 @@ class Celery:
         time_limit: int = ...,
         base: Type[_T],
         retry_kwargs: Dict[str, Any] = ...,
-        retry_backoff: bool = ...,
+        retry_backoff: Union[bool, int] = ...,
         retry_backoff_max: int = ...,
         retry_jitter: bool = ...,
         typing: bool = ...,
@@ -160,7 +160,7 @@ class Celery:
         time_limit: int = ...,
         base: None = ...,
         retry_kwargs: Dict[str, Any] = ...,
-        retry_backoff: bool = ...,
+        retry_backoff: Union[bool, int] = ...,
         retry_backoff_max: int = ...,
         retry_jitter: bool = ...,
         typing: bool = ...,


### PR DESCRIPTION
This PR fixes `Celery.task` signature:

- Changes `retry_backoff` argument to accept both bool or int values

See [Celery doc ](https://docs.celeryq.dev/en/master/userguide/tasks.html#Task.retry_backoff)for reference.