### PR TITLE
type rather than assign

### DIFF
--- a/kombu-stubs/mixins.pyi
+++ b/kombu-stubs/mixins.pyi
@@ -8,8 +8,8 @@ from kombu.transport.base import Channel
 from kombu.utils.limits import TokenBucket
 
 class ConsumerMixin:
-    connect_max_retries = Optional[int]
-    should_stop = bool
+    connect_max_retries: Optional[int]
+    should_stop: bool
     def get_consumers(
         self, Consumer: Callable[..., MessagingConsumer], channel: Channel
     ) -> Sequence[MessagingConsumer]: ...


### PR DESCRIPTION
fix `ConsumerMixin` props that were assigned a type rather than annotated with one