### PR TITLE
Don't lose function signature when decorated with Signal.connect

### DIFF
--- a/celery-stubs/utils/dispatch/signal.pyi
+++ b/celery-stubs/utils/dispatch/signal.pyi
@@ -1,11 +1,22 @@
-from typing import Any, Callable, Optional, TypeVar
+from typing import Any, Callable, Optional, TypeVar, overload
 
 _F = TypeVar("_F", bound=Callable[..., Any])
 
 class Signal:
+    @overload
     def connect(
         self,
-        receiver: Callable[..., Any] = ...,
+        receiver: _F,
+        sender: Optional[Any] = ...,
+        weak: bool = ...,
+        dispatch_uid: str = ...,
+        retry: bool = ...,
+    ) -> _F: ...
+
+    @overload
+    def connect(
+        self,
+        *,
         sender: Optional[Any] = ...,
         weak: bool = ...,
         dispatch_uid: str = ...,


### PR DESCRIPTION
Hi, I realised that my signal receivers lost their signature when decorated with `Signal.connect`

Currently:

```
tests/test_celery.py:198:17: note: Revealed type is "def [_F <: def (*Any, **Any) -> Any] (_F`-1) -> _F`-1"
```

With this change set applied:

```
tests/test_celery.py:198:17: note: Revealed type is "def (sender: celery.app.base.Celery, **kwargs: builtins.object)"
```

Output taken from adding a `reveal_type(setup_periodic_tasks)` at line 198, here:

https://github.com/sbdchd/celery-types/blob/e5cb7723968416b2c473179a12e5d709199e9bb5/tests/test_celery.py#L174-L198