### PR TITLE
celery: Separate kwargs-only arguments, add a few missing args

### DIFF
--- a/celery-stubs/app/task.pyi
+++ b/celery-stubs/app/task.pyi
@@ -81,6 +81,7 @@ class Task(Generic[_P, _R]):
         link: Optional[Union[Signature[Any], List[Signature[Any]]]] = ...,
         link_error: Optional[Union[Signature[Any], List[Signature[Any]]]] = ...,
         shadow: Optional[str] = ...,
+        *,
         # options
         countdown: float = ...,
         eta: datetime = ...,
@@ -96,6 +97,9 @@ class Task(Generic[_P, _R]):
         add_to_parent: bool = ...,
         publisher: kombu.Producer = ...,
         headers: Dict[str, str] = ...,
+        ignore_result: bool = ...,
+        time_limit: int = ...,
+        soft_time_limit: int = ...,
     ) -> celery.result.AsyncResult[_R]: ...
     def shadow_name(
         self, args: Tuple[Any, ...], kwargs: Dict[str, Any], options: Dict[str, Any]
@@ -118,6 +122,7 @@ class Task(Generic[_P, _R]):
         eta: Optional[datetime] = ...,
         countdown: Optional[float] = ...,
         max_retries: Optional[int] = ...,
+        *,
         # options
         task_id: Optional[str] = ...,
         producer: Optional[kombu.Producer] = ...,
@@ -136,6 +141,9 @@ class Task(Generic[_P, _R]):
         add_to_parent: bool = ...,
         publisher: kombu.Producer = ...,
         headers: Dict[str, str] = ...,
+        ignore_result: bool = ...,
+        time_limit: int = ...,
+        soft_time_limit: int = ...,
     ) -> Retry: ...
     def apply(
         self,
@@ -149,6 +157,12 @@ class Task(Generic[_P, _R]):
         logfile: Optional[str] = ...,
         loglevel: Optional[str] = ...,
         headers: Optional[Mapping[str, str]] = ...,
+        *,
+        # options
+        ignore_result: bool = ...,
+        exchange: str = ...,
+        routing_key: str = ...,
+        priority: int = ...,
     ) -> EagerResult[_R]: ...
     def AsyncResult(
         self, task_id: str, **kwargs: Any

--- a/celery-stubs/canvas.pyi
+++ b/celery-stubs/canvas.pyi
@@ -35,6 +35,7 @@ class Signature(Dict[str, Any], Generic[_R]):
         subtask_type: Optional[Any] = ...,
         immutable: bool = ...,
         app: Optional[Celery] = ...,
+        *,
         # **ex expanded
         task_id: Optional[str] = ...,
         producer: Optional[kombu.Producer] = ...,
@@ -72,6 +73,7 @@ class Signature(Dict[str, Any], Generic[_R]):
         args: Optional[Tuple[Any]] = ...,
         kwargs: Optional[Dict[str, Any]] = ...,
         route_name: Optional[str] = ...,
+        *,
         # options
         task_id: Optional[str] = ...,
         producer: Optional[kombu.Producer] = ...,
@@ -98,6 +100,7 @@ class Signature(Dict[str, Any], Generic[_R]):
         self,
         args: Optional[Tuple[Any, ...]] = ...,
         kwargs: Optional[Dict[str, Any]] = ...,
+        *,
         # **ex expanded
         task_id: Optional[str] = ...,
         producer: Optional[kombu.Producer] = ...,
@@ -138,6 +141,7 @@ class Signature(Dict[str, Any], Generic[_R]):
     def set(
         self,
         immutable: Optional[bool] = ...,
+        *,
         # **options expanded
         task_id: Optional[str] = ...,
         producer: Optional[kombu.Producer] = ...,
@@ -226,6 +230,7 @@ class _basemap(Signature[Any]):
         self,
         task: Optional[Task[Any, Any]],
         it: Iterable[Any],
+        *,
         # Signature extras
         args: Optional[Tuple[Any, ...]] = ...,
         kwargs: Optional[Dict[str, Any]] = ...,
@@ -264,6 +269,7 @@ class chunks(Signature[Any]):
         task: Optional[Task[Any, Any]],
         it: Iterable[Any],
         n: int,
+        *,
         # Signature extras
         args: Optional[Tuple[Any, ...]] = ...,
         kwargs: Optional[Dict[str, Any]] = ...,
@@ -347,6 +353,7 @@ class chord(Signature[Any]):
         args: Optional[Tuple[Any, ...]] = ...,
         kwargs: Optional[Dict[str, Any]] = ...,
         app: Optional[Celery] = ...,
+        *,
         # from Signature
         options: Optional[Dict[str, Any]] = ...,
         type: Optional[Any] = ...,


### PR DESCRIPTION
* Separated keyword-only arguments with `*` to disallow passing them positionally.
* Task.retry and Task.apply_async were missing `ignore_result`, `time_limit`, `soft_time_limit` (https://docs.celeryq.dev/en/stable/reference/celery.app.task.html#celery.app.task.Task.apply_async)
* Task.apply was missing `ignore_result`, `exchange`, `routing_key`, `priority` (reverse engineered from code)
