### PR TITLE
Add steps attribute to Celery app declaration

### DIFF
--- a/celery-stubs/app/base.pyi
+++ b/celery-stubs/app/base.pyi
@@ -2,6 +2,7 @@ import datetime
 from typing import (
     Any,
     Callable,
+    DefaultDict,
     Dict,
     List,
     NoReturn,
@@ -42,6 +43,8 @@ _P = ParamSpec("_P")
 _R = TypeVar("_R")
 
 class Celery:
+    steps: DefaultDict[str, set[Any]]
+
     on_configure: Signal
     on_after_configure: Signal
     on_after_finalize: Signal


### PR DESCRIPTION
See: https://docs.celeryq.dev/en/stable/userguide/extending.html#installing-bootsteps.

Related code: https://github.com/celery/celery/blob/93bccdce88de24713aa935ec590f067925fd8179/celery/app/base.py#L245