### PR TITLE
Add after_return and on_retry args to celery task decorator

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,10 @@
-# Taken from: https://jacobian.org/til/github-actions-poetry/
-on: push
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - "**"
+  pull_request:
 
 jobs:
   test:
@@ -14,11 +19,11 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/.local
-          key: poetry-1.1.9-0
+          key: poetry-1.3.2-0
 
       - uses: snok/install-poetry@v1
         with:
-          version: 1.1.9
+          version: 1.3.2
           virtualenvs-create: true
           virtualenvs-in-project: true
 

--- a/celery-stubs/app/base.pyi
+++ b/celery-stubs/app/base.pyi
@@ -99,6 +99,8 @@ class Celery:
         resultrepr_maxsize: int = ...,
         request_stack: _LocalStack = ...,
         abstract: bool = ...,
+        after_return: Callable[..., Any] = ...,
+        on_retry: Callable[..., Any] = ...,
     ) -> CeleryTask[_P, _R]: ...
     def on_init(self) -> None: ...
     def set_current(self) -> None: ...
@@ -143,6 +145,8 @@ class Celery:
         request_stack: _LocalStack = ...,
         abstract: bool = ...,
         queue: str = ...,
+        after_return: Callable[..., Any] = ...,
+        on_retry: Callable[..., Any] = ...,
     ) -> Callable[[Callable[..., Any]], _T]: ...
     @overload
     def task(
@@ -179,6 +183,8 @@ class Celery:
         request_stack: _LocalStack = ...,
         abstract: bool = ...,
         queue: str = ...,
+        after_return: Callable[..., Any] = ...,
+        on_retry: Callable[..., Any] = ...,
     ) -> Callable[[Callable[_P, _R]], CeleryTask[_P, _R]]: ...
     @overload
     def task(
@@ -215,6 +221,8 @@ class Celery:
         request_stack: _LocalStack = ...,
         abstract: bool = ...,
         queue: str = ...,
+        after_return: Callable[..., Any] = ...,
+        on_retry: Callable[..., Any] = ...,
     ) -> Callable[
         [Callable[Concatenate[CeleryTask[_P, _R], _P], _R]], CeleryTask[_P, _R]
     ]: ...


### PR DESCRIPTION
Hi,

I've added the `after_return` and `on_retry` args that where missing from the `task` decorator.

- `after_return` - https://docs.celeryq.dev/en/stable/reference/celery.app.task.html#celery.app.task.Task.after_return
- `on_retry` - https://docs.celeryq.dev/en/stable/reference/celery.app.task.html#celery.app.task.Task.on_retry

