### PR TITLE
Add typings for celery.app.task.Context (fixes #103)

### DIFF
--- a/celery-stubs/app/__init__.pyi
+++ b/celery-stubs/app/__init__.pyi
@@ -12,6 +12,7 @@ from celery.app import beat as beat
 from celery.app import control as control
 from celery.app import events as events
 from celery.app import task as task
+from celery.app.task import Context
 from celery.app.task import Task as Task
 from celery.utils.threads import _LocalStack
 from typing_extensions import ParamSpec
@@ -53,7 +54,7 @@ def shared_task(
     expires: float | datetime | None = ...,
     priority: int | None = ...,
     resultrepr_maxsize: int = ...,
-    request_stack: _LocalStack = ...,
+    request_stack: _LocalStack[Context] = ...,
     abstract: bool = ...,
     queue: str = ...,
 ) -> Callable[[Callable[_P, _R]], Task[_P, _R]]: ...
@@ -88,7 +89,7 @@ def shared_task(
     expires: float | datetime | None = ...,
     priority: int | None = ...,
     resultrepr_maxsize: int = ...,
-    request_stack: _LocalStack = ...,
+    request_stack: _LocalStack[Context] = ...,
     abstract: bool = ...,
     queue: str = ...,
 ) -> Callable[[Callable[Concatenate[Task[_P, _R], _P], _R]], Task[_P, _R]]: ...
@@ -123,7 +124,7 @@ def shared_task(
     expires: float | datetime | None = ...,
     priority: int | None = ...,
     resultrepr_maxsize: int = ...,
-    request_stack: _LocalStack = ...,
+    request_stack: _LocalStack[Context] = ...,
     abstract: bool = ...,
     queue: str = ...,
 ) -> Callable[[Callable[..., Any]], _T]: ...

--- a/celery-stubs/app/base.pyi
+++ b/celery-stubs/app/base.pyi
@@ -19,6 +19,7 @@ from celery.app.events import Events
 from celery.app.log import Logging
 from celery.app.registry import TaskRegistry
 from celery.app.routes import Router
+from celery.app.task import Context
 from celery.app.task import Task as CeleryTask
 from celery.app.utils import Settings
 from celery.apps.worker import Worker as CeleryWorker
@@ -132,7 +133,7 @@ class Celery:
         expires: float | datetime.datetime | None = ...,
         priority: int | None = ...,
         resultrepr_maxsize: int = ...,
-        request_stack: _LocalStack = ...,
+        request_stack: _LocalStack[Context] = ...,
         abstract: bool = ...,
         after_return: Callable[..., Any] = ...,
         on_retry: Callable[..., Any] = ...,
@@ -177,7 +178,7 @@ class Celery:
         expires: float | datetime.datetime | None = ...,
         priority: int | None = ...,
         resultrepr_maxsize: int = ...,
-        request_stack: _LocalStack = ...,
+        request_stack: _LocalStack[Context] = ...,
         abstract: bool = ...,
         queue: str = ...,
         after_return: Callable[..., Any] = ...,
@@ -215,7 +216,7 @@ class Celery:
         expires: float | datetime.datetime | None = ...,
         priority: int | None = ...,
         resultrepr_maxsize: int = ...,
-        request_stack: _LocalStack = ...,
+        request_stack: _LocalStack[Context] = ...,
         abstract: bool = ...,
         queue: str = ...,
         after_return: Callable[..., Any] = ...,
@@ -253,7 +254,7 @@ class Celery:
         expires: float | datetime.datetime | None = ...,
         priority: int | None = ...,
         resultrepr_maxsize: int = ...,
-        request_stack: _LocalStack = ...,
+        request_stack: _LocalStack[Context] = ...,
         abstract: bool = ...,
         queue: str = ...,
         after_return: Callable[..., Any] = ...,

--- a/celery-stubs/utils/threads.pyi
+++ b/celery-stubs/utils/threads.pyi
@@ -1,1 +1,6 @@
-class _LocalStack: ...
+from typing import Generic, TypeVar
+
+_T = TypeVar("_T")
+
+class _LocalStack(Generic[_T]):
+    top: _T | None

--- a/tests/test_celery.py
+++ b/tests/test_celery.py
@@ -75,7 +75,8 @@ def send_twitter_status(self: Task[Any, Any], oauth: str, tweet: str) -> None:
         if exc.errno == errno.ENOMEM:
             raise Reject(exc, requeue=False)
 
-        if not self.request.delivery_info["redelivered"]:
+        delivery_info = self.request.delivery_info or {}
+        if not delivery_info.get("redelivered"):
             raise Reject("no reason", requeue=True)
 
     self.update_state(state="SUCCESS", meta={"foo": "bar"})


### PR DESCRIPTION
`Task.request` is actually not a `Request` but a `Context` as the docstring on the latter also calls out:

```
class Context:
    """Task request variables (Task.request)."""
```

This PR adds the definition for the `Context` (property names copied from the class definition and concrete types on a best effort basis).

Additionally, this PR adds makes `_LocalStack` generic and adds the `top: _T | None` property.