### PR TITLE
clean up build dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,5 +98,5 @@ ban-relative-imports = "all"
 
 
 [build-system]
-requires = ["poetry>=1.4", "setuptools"]
+requires = ["poetry-core>=1.5.2"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
I'm working on this package in [nixpkgs](https://github.com/NixOS/nixpkgs) and noticed that the build dependencies can be streamlined to only depend upon `poetry-core`. I picked poetry-core version 1.5.2 since that is what poetry 1.4 depends on.