### PR TITLE
fix celery.app.task.Context.parent_id type

### DIFF
--- a/celery-stubs/app/task.pyi
+++ b/celery-stubs/app/task.pyi
@@ -46,7 +46,7 @@ class Context:
     logfile: str | None
     loglevel: int | None
     origin: Any
-    parent_id: int | None
+    parent_id: str | None
     properties: Any | None
     retries: int
     reply_to: Any


### PR DESCRIPTION
fix #139 