### PR TITLE
celery: add celery.utils.dispatch.Signal.send/send_robust

### DIFF
--- a/celery-stubs/utils/dispatch/signal.pyi
+++ b/celery-stubs/utils/dispatch/signal.pyi
@@ -22,3 +22,7 @@ class Signal:
         dispatch_uid: str = ...,
         retry: bool = ...,
     ) -> Callable[[_F], _F]: ...
+    def send(
+        self, sender: Any | None, **named: Any
+    ) -> list[tuple[Callable[..., Any], Any]]: ...
+    send_robust = send


### PR DESCRIPTION
As documented in https://docs.celeryq.dev/en/stable/internals/reference/celery.utils.dispatch.html#celery.utils.dispatch.Signal.send.