### PR TITLE
Add misc missing types

### DIFF
--- a/celery-stubs/_state.pyi
+++ b/celery-stubs/_state.pyi
@@ -5,3 +5,5 @@ from celery.app.task import Task
 
 current_app: Celery
 current_task: Task[Any, Any]
+
+def get_current_task() -> Task[Any, Any]: ...

--- a/celery-stubs/app/task.pyi
+++ b/celery-stubs/app/task.pyi
@@ -37,7 +37,7 @@ class Context:
     expires: int | None
     group: str | None
     group_index: int | None
-    headers: Mapping[str, Any] | None
+    headers: dict[str, Any] | None
     hostname: str | None
     id: str | None
     ignore_result: bool

--- a/celery-stubs/utils/log.pyi
+++ b/celery-stubs/utils/log.pyi
@@ -1,4 +1,6 @@
-from logging import Logger
+from celery.utils.term import colored
+from logging import Logger, Formatter, _SysExcInfoType
+from typing import ClassVar
 
 class LoggingProxy: ...
 
@@ -7,3 +9,11 @@ def get_task_logger(name: str) -> Logger: ...
 
 task_logger: Logger
 worker_logger: Logger
+
+class ColorFormatter(Formatter):
+    use_color: bool
+
+    COLORS: ClassVar[dict[str, colored]]
+    colors: ClassVar[dict[str, colored]]
+
+    def __init__(self, fmt: str | None = ..., use_color: bool = ...) -> None: ...

--- a/celery-stubs/utils/log.pyi
+++ b/celery-stubs/utils/log.pyi
@@ -1,6 +1,7 @@
-from celery.utils.term import colored
-from logging import Logger, Formatter, _SysExcInfoType
+from logging import Formatter, Logger
 from typing import ClassVar
+
+from celery.utils.term import colored
 
 class LoggingProxy: ...
 
@@ -15,5 +16,4 @@ class ColorFormatter(Formatter):
 
     COLORS: ClassVar[dict[str, colored]]
     colors: ClassVar[dict[str, colored]]
-
     def __init__(self, fmt: str | None = ..., use_color: bool = ...) -> None: ...


### PR DESCRIPTION
This PR adds a few missing types:
* `ColorFormatter`
* `get_current_task`

and it fixes the definition of `Context.headers` to be a dict (mutable)