### PR TITLE
celery: More precise typing for Task.replace(...)

### DIFF
--- a/celery-stubs/app/task.pyi
+++ b/celery-stubs/app/task.pyi
@@ -23,6 +23,7 @@ from typing_extensions import ParamSpec
 
 _P = ParamSpec("_P")
 _R = TypeVar("_R")
+_SigR = TypeVar("_SigR")
 
 class Context:
     args: Sequence[Any] | None
@@ -219,7 +220,7 @@ class Task(Generic[_P, _R]):
         retry_policy: Mapping[str, int] | None = ...,
         **fields: Any,
     ) -> list[tuple[object, object]]: ...
-    def replace(self, sig: Signature[Any]) -> None: ...
+    def replace(self, sig: Signature[_SigR]) -> _SigR: ...
     @overload
     def add_to_chord(
         self, sig: Signature[Any], lazy: Literal[True]


### PR DESCRIPTION
`Task.replace()` either `apply`s the provided signature eagerly, or raises `Ignore` [1]. Here's a silly example which this PR fixes:

```python
from celery import Celery, Task

app = Celery()

@app.task(bind=True)
def maybe_replace(task: Task, replace: bool) -> int:
    if replace:
        return task.replace(maybe_replace.s(replace=False))   # type: ignore[func-returns-value]
    else:
        return 10
```

[1] https://github.com/celery/celery/blob/1b35d1d5966614ce36af75808ee21b0d2db6745d/celery/app/task.py#L1105-L1109