### PR TITLE
Add celery.app.task.Task.before_start

### DIFF
--- a/celery-stubs/app/task.pyi
+++ b/celery-stubs/app/task.pyi
@@ -236,6 +236,9 @@ class Task(Generic[_P, _R]):
         meta: dict[str, Any] | None = ...,
         **kwargs: Any,
     ) -> None: ...
+    def before_start(
+        self, task_id: str, args: tuple[Any, ...], kwargs: dict[str, Any]
+    ) -> None: ...
     def on_success(
         self, retval: Any, task_id: str, args: tuple[Any, ...], kwargs: dict[str, Any]
     ) -> None: ...


### PR DESCRIPTION
In 5.2, Celery introduced a callback on the base `Task` class called `before_start`. This stubs out that interface.

Related code: https://github.com/celery/celery/blob/f110e3c797df36e8b3efb40449b028664c88f6ea/celery/app/task.py#L1019-L1031

Related docs:
https://docs.celeryq.dev/en/stable/userguide/tasks.html#before_start