### PR TITLE
Add license info to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ description = "Type stubs for Celery and its related packages"
 repository = "https://github.com/sbdchd/celery-types"
 readme = "README.md"
 authors = ["Steve Dignam <steve@dignam.xyz>"]
+license = "Apache-2.0"
 keywords = [
     "celery",
     "kombu",


### PR DESCRIPTION
This enables automatic license checks and license will automatically be listed on PyPI. See also [Writing your pyproject.toml](https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license-and-license-files)