### PR TITLE
celery: Allow unsealed kwargs when custom task base is provided

### DIFF
--- a/celery-stubs/app/__init__.pyi
+++ b/celery-stubs/app/__init__.pyi
@@ -131,5 +131,5 @@ def shared_task(
     request_stack: _LocalStack[Context] = ...,
     abstract: bool = ...,
     queue: str = ...,
-    pydantic: bool = ...,
+    **kwargs: Any,
 ) -> Callable[[Callable[..., Any]], _T]: ...

--- a/celery-stubs/app/__init__.pyi
+++ b/celery-stubs/app/__init__.pyi
@@ -131,5 +131,5 @@ def shared_task(
     request_stack: _LocalStack[Context] = ...,
     abstract: bool = ...,
     queue: str = ...,
-    **kwargs: Any,
+    **options: Any,
 ) -> Callable[[Callable[..., Any]], _T]: ...


### PR DESCRIPTION
If a task provides a custom Task base class (via the `base` kwarg), additional arbitrary decorator kwargs should be allowed (since custom base classes tend to accept their own config options this way).

For example, the `Singleton` base class from https://github.com/steinitzu/celery-singleton accepts additional arguments such as `unique_on` and `raise_on_exception`, which violate the current `shared_task` stub when present.