### PR TITLE
ci: Upgrade `actions/cache` to v4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
           python-version: 3.11
 
       - name: cache poetry install
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.local
           key: poetry-1.7.1-0
@@ -29,7 +29,7 @@ jobs:
 
       - name: cache deps
         id: cache-deps
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: .venv
           key: pydeps-${{ hashFiles('**/poetry.lock') }}


### PR DESCRIPTION
The older version stopped working back in February (https://github.com/actions/toolkit/discussions/1890). Bumping to the latest `v4` in hopes that it gets the test CI workflow able to run again so that some other PRs can be merged :crossed_fingers: 