### PR TITLE
now max_retries may be None in all overloads

### DIFF
--- a/celery-stubs/app/base.pyi
+++ b/celery-stubs/app/base.pyi
@@ -235,7 +235,7 @@ class Celery:
         bind: Literal[True],
         autoretry_for: Sequence[type[BaseException]] = ...,
         dont_autoretry_for: Sequence[type[BaseException]] = ...,
-        max_retries: int = ...,
+        max_retries: int | None = ...,
         default_retry_delay: int = ...,
         acks_late: bool = ...,
         ignore_result: bool = ...,


### PR DESCRIPTION
This should resolve a bug described in https://github.com/sbdchd/celery-types/issues/191