### PR TITLE
is_aborted does not require task_id

### DIFF
--- a/celery-stubs/contrib/abortable.pyi
+++ b/celery-stubs/contrib/abortable.pyi
@@ -1,4 +1,4 @@
-from typing import Any, Generic, ParamSpec, TypeVar
+from typing import Any, Generic, ParamSpec, TypeVar, overload
 
 from celery import Task
 from celery.result import AsyncResult
@@ -20,4 +20,7 @@ class AbortableTask(Task[_P, _R_co], Generic[_P, _R_co]):
 
     @override
     def AsyncResult(self, task_id: str) -> AbortableAsyncResult[_R_co]: ...  # type: ignore[override]  # pyright: ignore[reportIncompatibleMethodOverride]
+    @overload
     def is_aborted(self, *, task_id: str, **kwargs: Any) -> bool: ...
+    @overload
+    def is_aborted(self, **kwargs: Any) -> bool: ...

--- a/tests/test_celery.py
+++ b/tests/test_celery.py
@@ -17,6 +17,7 @@ from typing_extensions import assert_type, override
 if TYPE_CHECKING:
     from collections.abc import Iterator
 
+    from celery.contrib.abortable import AbortableTask
     from celery.contrib.django.task import DjangoTask
 
 app = celery.Celery()
@@ -364,3 +365,7 @@ def test_celery_top_level_exports() -> None:
 def test_djangotask(task: DjangoTask[[int, int], Any]) -> None:
     task.delay_on_commit(1, 2)
     task.apply_async_on_commit((1, 2), countdown=10.0)
+
+
+def test_abortabletask(task: AbortableTask[[], None]) -> None:
+    task.is_aborted()


### PR DESCRIPTION
The `is_aborted` method accepts either no arguments, or a single argument to override the `task_id` that is being checked.  The current type signature correctly describes the second case but not the first.

https://github.com/celery/celery/blob/aef7f130e3ca547c49d3d581a831927458fc1a71/celery/contrib/abortable.py#L147

This is kind of a drive by contribution - I've tried to copy the current testing style, let me know if there are any other conventions that I should be following.